### PR TITLE
Feature/reduce noise price error

### DIFF
--- a/src/helpers/EthereumClient.js
+++ b/src/helpers/EthereumClient.js
@@ -38,13 +38,7 @@ class EthereumClient {
         addressIndex: 0,
         numAddresses: 5
       })
-      this._provider.engine.on('error', error => {
-        logger.error({
-          msg: 'Error in Web3 engine %s: %s',
-          params: [ this._url, error.toString() ],
-          error
-        })
-      })
+      this._provider.engine.on('error', _printNodeError)
     } else {
       // this._provider = new Web3.providers.HttpProvider(this._url)
       throw new Error('The MNEMONIC is required')
@@ -533,6 +527,34 @@ function _handleGetGasPriceError (error) {
     average: DAFAULT_GAS_PRICE_AVERAGE,
     fast: DAFAULT_GAS_PRICE_FAST
   }
+}
+
+// We handle this error separatelly, because node throw this error from time to
+// time, and it disapears after some seconds
+const NODE_ERROR_EMPTY_RESPONSE = 'Error: Invalid JSON RPC response: ""'
+const SILENT_TIME_FOR_NODE_ERRORS = 120000 // 120s
+let reduceWarnLevelForNodeErrors = false
+function _printNodeError (error) {
+  const errorMessage = error.message
+  let debugLevel
+  if (errorMessage === NODE_ERROR_EMPTY_RESPONSE) {
+    if (reduceWarnLevelForNodeErrors) {
+      debugLevel = 'warn'
+    } else {
+      debugLevel = 'error'
+      reduceWarnLevelForNodeErrors = true
+      setTimeout(() => {
+        reduceWarnLevelForNodeErrors = false
+      }, SILENT_TIME_FOR_NODE_ERRORS)
+    }
+  } else {
+    debugLevel = 'error'
+  }
+  logger[debugLevel]({
+    msg: 'Error in Ethereum node %s: %s',
+    params: [ this._url, error.message ]
+    // error // We hide the stack trace, is not usefull in this case (dispached by web3 internals)
+  })
 }
 
 module.exports = EthereumClient

--- a/src/repositories/PriceRepo/strategies/sequence.js
+++ b/src/repositories/PriceRepo/strategies/sequence.js
@@ -24,18 +24,20 @@ async function _doGetPrice ({ tokenA, tokenB }, feeds) {
   return _getPriceRepo(bestFeed)
     .getPrice({ tokenA, tokenB })
     .catch(error => {
+      // Display a ERROR or WARN depending on if we have more feeds
       const msg = 'Error getting the price from "%s". '
-      const params = [ bestFeed,
-        remainingFeeds.length > 0 ? 'remaining feeds: %s' + remainingFeeds.join(',') : 'No feeds left'
-      ]
+      let feedsLeftMsg, debugLevel
+      if (remainingFeeds.length > 0) {
+        feedsLeftMsg = 'remaining feeds: %s' + remainingFeeds.join(',')
+        debugLevel = 'warn'
+      } else {
+        feedsLeftMsg = 'No feeds left'
+        debugLevel = 'error'
+      }
+      const params = [ bestFeed, feedsLeftMsg ]
 
-      auctionLogger.error({
-        sellToken: tokenA,
-        buyToken: tokenB,
-        msg,
-        params
-      })
-      auctionLogger.warn({
+      // Print the log
+      auctionLogger[debugLevel]({
         sellToken: tokenA,
         buyToken: tokenB,
         msg,
@@ -44,8 +46,10 @@ async function _doGetPrice ({ tokenA, tokenB }, feeds) {
       })
 
       if (remainingFeeds.length > 0) {
+        // Retry with next feeds
         return _doGetPrice({ tokenA, tokenB }, remainingFeeds)
       } else {
+        // No more feeds avaliable
         throw new Error('Not more feeds avaliable. All of the price feeds have failed')
       }
     })

--- a/src/repositories/PriceRepo/strategies/sequence.js
+++ b/src/repositories/PriceRepo/strategies/sequence.js
@@ -25,7 +25,6 @@ async function _doGetPrice ({ tokenA, tokenB }, feeds) {
     .getPrice({ tokenA, tokenB })
     .catch(error => {
       // Display a ERROR or WARN depending on if we have more feeds
-      const msg = 'Error getting the price from "%s". '
       let feedsLeftMsg, debugLevel
       if (remainingFeeds.length > 0) {
         feedsLeftMsg = 'remaining feeds: %s' + remainingFeeds.join(',')
@@ -34,15 +33,15 @@ async function _doGetPrice ({ tokenA, tokenB }, feeds) {
         feedsLeftMsg = 'No feeds left'
         debugLevel = 'error'
       }
-      const params = [ bestFeed, feedsLeftMsg ]
+      const params = [ bestFeed, error.message, feedsLeftMsg ]
+      const msg = 'Error getting the price from "%s": %s. %s'
 
       // Print the log
       auctionLogger[debugLevel]({
         sellToken: tokenA,
         buyToken: tokenB,
         msg,
-        params,
-        error
+        params
       })
 
       if (remainingFeeds.length > 0) {


### PR DESCRIPTION
This PR is to reduce the noise generated in the logs.

- Some stacktraces that doesn't add value are removed
- The sequence price strategy reduce to WARN getting the price from price feeds (unless it's the last one in the backup list)
- The Ethereum node errors will notify the first error, and then, they'll go silent for 2min