### PR TITLE
Set accountIndex independently from the presence of botAddress

### DIFF
--- a/src/bots/SafeModuleBalanceCheckBot.js
+++ b/src/bots/SafeModuleBalanceCheckBot.js
@@ -31,8 +31,9 @@ class SafeModuleBalanceCheckBot extends BalanceCheckBot {
       tokens
     })
 
-    // assert(operatorAddress, 'operatorAddress is required')
-    // this._operatorAddress = operatorAddress
+    assert(accountIndex !== undefined && accountIndex >= 0, 'AccountIndex is mandatory')
+    // Set accountIndex independently from the botAddress being setted
+    this._accountIndex = accountIndex
   }
 
   async setAddress () {


### PR DESCRIPTION
Set accountIndex in SafeModuleBalanceCheckBot independently from the presence of botAddress