### PR TITLE
Add wei conversion using numberUtil to avoid 15 digit issue in CLI command

### DIFF
--- a/src/cli/cliCommands/buyCmd.js
+++ b/src/cli/cliCommands/buyCmd.js
@@ -1,4 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
+const { toWei } = require('../../helpers/numberUtil')
 
 const getAddress = require('../../helpers/getAddress')
 const getDxInfoService = require('../../services/DxInfoService')
@@ -40,7 +41,7 @@ function registerCommand ({ cli, logger }) {
         sellToken,
         buyToken,
         auctionIndex,
-        amount: amount * 1e18,
+        amount: toWei(amount),
         from
       })
       logger.info('The buy was succesful. Transaction: %s', buyResult.tx)

--- a/src/cli/cliCommands/depositCmd.js
+++ b/src/cli/cliCommands/depositCmd.js
@@ -1,4 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
+const { toWei } = require('../../helpers/numberUtil')
 
 const getAddress = require('../../helpers/getAddress')
 const getDxTradeService = require('../../services/DxTradeService')
@@ -32,7 +33,7 @@ function registerCommand ({ cli, logger }) {
       )
       const depositResult = await dxTradeService.deposit({
         token,
-        amount: amount * 1e18,
+        amount: toWei(amount),
         accountAddress
       })
       logger.info('The delivery was successful. Transaction: %s', depositResult.tx)

--- a/src/cli/cliCommands/sellCmd.js
+++ b/src/cli/cliCommands/sellCmd.js
@@ -1,4 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
+const { toWei } = require('../../helpers/numberUtil')
 
 const getAddress = require('../../helpers/getAddress')
 const getDxInfoService = require('../../services/DxInfoService')
@@ -55,7 +56,7 @@ function registerCommand ({ cli, logger }) {
         sellToken,
         buyToken,
         auctionIndex,
-        amount: amount * 1e18,
+        amount: toWei(amount),
         from: address
       })
       logger.info('The sell was succesful. Transaction: %s', buyResult.tx)

--- a/src/cli/cliCommands/sendCmd.js
+++ b/src/cli/cliCommands/sendCmd.js
@@ -1,4 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
+const { toWei } = require('../../helpers/numberUtil')
 
 const getAddress = require('../../helpers/getAddress')
 const getDxTradeService = require('../../services/DxTradeService')
@@ -30,7 +31,7 @@ function registerCommand ({ cli, logger }) {
       )
       const sendTokensResult = await dxTradeService.sendTokens({
         token,
-        amount: amount * 1e18,
+        amount: toWei(amount),
         fromAddress: owner,
         toAddress: account
       })

--- a/src/cli/cliCommands/setAllowance.js
+++ b/src/cli/cliCommands/setAllowance.js
@@ -1,4 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
+const { toWei } = require('../../helpers/numberUtil')
 
 const getDxTradeService = require('../../services/DxTradeService')
 
@@ -27,7 +28,7 @@ function registerCommand ({ cli, logger }) {
       const transactionResult = await dxTradeService.setAllowance({
         token,
         accountAddress,
-        amount: amount * 1e18
+        amount: toWei(amount)
       })
 
       logger.info({

--- a/src/cli/cliCommands/unwrapEtherCmd.js
+++ b/src/cli/cliCommands/unwrapEtherCmd.js
@@ -1,4 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
+const { toWei } = require('../../helpers/numberUtil')
 
 const getAddress = require('../../helpers/getAddress')
 const getDxTradeService = require('../../services/DxTradeService')
@@ -27,7 +28,7 @@ function registerCommand ({ cli, logger }) {
       )
 
       const withdrawEtherResult = await dxTradeService.withdrawEther({
-        amount: amount * 1e18,
+        amount: toWei(amount),
         accountAddress: address
       })
       logger.info('The unwrap was succesful. Transaction: %s', withdrawEtherResult.tx)

--- a/src/cli/cliCommands/usdPriceComand.js
+++ b/src/cli/cliCommands/usdPriceComand.js
@@ -1,5 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
-const numberUtil = require('../../helpers/numberUtil')
+const { round, toWei } = require('../../helpers/numberUtil')
 
 const getDxInfoService = require('../../services/DxInfoService')
 
@@ -18,10 +18,10 @@ function registerCommand ({ cli, logger }) {
 
       const price = await dxInfoService.getPriceInUSD({
         token,
-        amount: amount * 1e18
+        amount: toWei(amount)
       })
       logger.info('The current price is: %s %s/USD',
-        numberUtil.round(price),
+        round(price),
         token
       )
     })

--- a/src/cli/cliCommands/withdrawCmd.js
+++ b/src/cli/cliCommands/withdrawCmd.js
@@ -1,4 +1,5 @@
 const cliUtils = require('../helpers/cliUtils')
+const { toWei } = require('../../helpers/numberUtil')
 
 const getAddress = require('../../helpers/getAddress')
 const getDxTradeService = require('../../services/DxTradeService')
@@ -29,7 +30,7 @@ function registerCommand ({ cli, logger }) {
       )
       const depositResult = await dxTradeService.withdraw({
         token,
-        amount: amount * 1e18,
+        amount: toWei(amount),
         accountAddress
       })
       logger.info('The withdraw was succesful. Transaction: %s', depositResult.tx)


### PR DESCRIPTION
We should convert to wei using `numberUtil.toWei()` in CLI commands to avoid 15 digit limitations when converting automatically from Number to BigNumber