### PR TITLE
Check WETH token also with address

### DIFF
--- a/src/repositories/AuctionRepo/AuctionRepoImpl.js
+++ b/src/repositories/AuctionRepo/AuctionRepoImpl.js
@@ -62,6 +62,7 @@ class AuctionRepoImpl extends Cacheable {
       MGN: contracts.mgn,
       OWL: contracts.owl
     }, contracts.erc20TokenContracts)
+    this._ethTokenAddress = this._tokens.WETH.address
 
     logger.debug({
       msg: `DX contract in address %s`,
@@ -1062,12 +1063,12 @@ just ${balance.div(1e18)} WETH (not able to unwrap ${amountBigNumber.div(1e18)} 
   async _assertMinimumFundingForAddToken ({ tokenA, actualAFunding, tokenB, actualBFunding }) {
     // get the funded value in USD
     let fundedValueUSD
-    if (tokenA === 'WETH') {
+    if (tokenA === 'WETH' || tokenA === this._ethTokenAddress) {
       fundedValueUSD = await this.getPriceInUSD({
         token: tokenA,
         amount: actualAFunding
       })
-    } else if (tokenB === 'WETH') {
+    } else if (tokenB === 'WETH' || tokenB === this._ethTokenAddress) {
       fundedValueUSD = await this.getPriceInUSD({
         token: tokenB,
         amount: actualBFunding
@@ -1141,7 +1142,7 @@ currentAuctionIndex=${currentAuctionIndex}`)
       params: [token, ethUsdPrice]
     })
     let amountInETH
-    if (token === 'WETH') {
+    if (token === 'WETH' || token === this._ethTokenAddress) {
       amountInETH = amountBN
     } else {
       const priceTokenETH = await this.getPriceInEth({ token })
@@ -1168,7 +1169,7 @@ currentAuctionIndex=${currentAuctionIndex}`)
     let amountInETH = amountOfUsd.div(ethUsdPrice)
 
     let amountInToken
-    if (token === 'WETH') {
+    if (token === 'WETH' || token === this._ethTokenAddress) {
       amountInToken = amountInETH
     } else {
       const priceTokenETH = await this.getPriceInEth({ token })

--- a/src/repositories/AuctionRepo/AuctionRepoImpl.js
+++ b/src/repositories/AuctionRepo/AuctionRepoImpl.js
@@ -62,7 +62,6 @@ class AuctionRepoImpl extends Cacheable {
       MGN: contracts.mgn,
       OWL: contracts.owl
     }, contracts.erc20TokenContracts)
-    this._ethTokenAddress = this._tokens.WETH.address
 
     logger.debug({
       msg: `DX contract in address %s`,
@@ -1063,12 +1062,12 @@ just ${balance.div(1e18)} WETH (not able to unwrap ${amountBigNumber.div(1e18)} 
   async _assertMinimumFundingForAddToken ({ tokenA, actualAFunding, tokenB, actualBFunding }) {
     // get the funded value in USD
     let fundedValueUSD
-    if (tokenA === 'WETH' || tokenA === this._ethTokenAddress) {
+    if (this.isTokenEth(tokenA)) {
       fundedValueUSD = await this.getPriceInUSD({
         token: tokenA,
         amount: actualAFunding
       })
-    } else if (tokenB === 'WETH' || tokenB === this._ethTokenAddress) {
+    } else if (this.isTokenEth(tokenB)) {
       fundedValueUSD = await this.getPriceInUSD({
         token: tokenB,
         amount: actualBFunding
@@ -1142,7 +1141,7 @@ currentAuctionIndex=${currentAuctionIndex}`)
       params: [token, ethUsdPrice]
     })
     let amountInETH
-    if (token === 'WETH' || token === this._ethTokenAddress) {
+    if (this.isTokenEth(token)) {
       amountInETH = amountBN
     } else {
       const priceTokenETH = await this.getPriceInEth({ token })
@@ -1169,7 +1168,7 @@ currentAuctionIndex=${currentAuctionIndex}`)
     let amountInETH = amountOfUsd.div(ethUsdPrice)
 
     let amountInToken
-    if (token === 'WETH' || token === this._ethTokenAddress) {
+    if (this.isTokenEth(token)) {
       amountInToken = amountInETH
     } else {
       const priceTokenETH = await this.getPriceInEth({ token })
@@ -1875,6 +1874,11 @@ volume: ${state}`)
 
   async getMagnoliaToken () {
     return this._tokens['MGN']
+  }
+
+  isTokenEth (token) {
+    return token === 'WETH' ||
+      token.toLowerCase() === this._tokens.WETH.address.toLowerCase()
   }
 
   _hasClosingPrice ({ sellToken, buyToken, auctionIndex }) {

--- a/src/services/DxInfoService/DxInfoService.js
+++ b/src/services/DxInfoService/DxInfoService.js
@@ -457,6 +457,10 @@ class DxInfoService {
     return this._getTokenInfoByAddress(magnoliaToken.address)
   }
 
+  isTokenEth (token) {
+    return this._auctionRepo.isTokenEth(token)
+  }
+
   async getTokenAddress (token) {
     return this._auctionRepo.getTokenAddress({ token })
   }

--- a/src/web/publicApi/markets-routes.js
+++ b/src/web/publicApi/markets-routes.js
@@ -1,4 +1,5 @@
 const formatUtil = require('../../helpers/formatUtil')
+const { ONE } = require('../../helpers/numberUtil')
 const _tokenPairSplit = formatUtil.tokenPairSplit
 
 const addCacheHeader = require('../helpers/addCacheHeader')
@@ -132,63 +133,123 @@ function createRoutes ({ dxInfoService, reportService },
     }
   })
 
+  function _safeMedian (req, res, token) {
+    addCacheHeader({ res, time: CACHE_TIMEOUT_SHORT })
+    return dxInfoService.getOraclePrice({ token })
+  }
+
   routes.push({
-    path: '/:token-WETH/prices/safe-median',
+    path: '/:tokenPair/prices/safe-median',
     get (req, res) {
-      const token = req.params.token
-      addCacheHeader({ res, time: CACHE_TIMEOUT_SHORT })
-      return dxInfoService.getOraclePrice({ token })
+      const { sellToken, buyToken } = _tokenPairSplit(req.params.tokenPair)
+      const isSellTokenEth = dxInfoService.isTokenEth(sellToken)
+      const isBuyTokenEth = dxInfoService.isTokenEth(buyToken)
+
+      if (isSellTokenEth) {
+        // Price oracle always returns tokenA-WETH.
+        // We do inverse of result to return WETH-tokenA for convenience
+        return _safeMedian(req, res, buyToken).then(result => {
+          return ONE.div(result)
+        })
+      } else if (isBuyTokenEth) {
+        return _safeMedian(req, res, sellToken)
+      } else {
+        const error = new Error('Invalid `tokenPair`. At least one of the tokens must be WETH.')
+        error.type = 'INVALID_TOKEN_PAIR'
+        error.status = 412
+        throw error
+      }
     }
   })
 
-  routes.push({
-    path: '/:token-WETH/prices/custom-median',
-    get (req, res) {
-      const token = req.params.token
-      const time = req.query.time !== undefined
-        ? formatUtil.parseDateIso(req.query.time).getTime() / 1000
-        : DEFAULT_ORACLE_TIME
-      const maximumTimePeriod = req.query.maximumTimePeriod !== undefined
-        ? req.query.maximumTimePeriod : DEFAULT_MAXIMUM_TIME_PERIOD
-      const requireWhitelisted = req.query.requireWhitelisted !== undefined
-        ? req.query.requireWhitelisted === 'true' : DEFAULT_REQUIRED_WHITELISTED
-      const numberOfAuctions = req.query.numberOfAuctions !== undefined
-        ? req.query.numberOfAuctions : DEFAULT_NUMBER_OF_AUCTIONS
+  function _customMedian (req, res, token) {
+    const time = req.query.time !== undefined
+      ? formatUtil.parseDateIso(req.query.time).getTime() / 1000
+      : DEFAULT_ORACLE_TIME
+    const maximumTimePeriod = req.query.maximumTimePeriod !== undefined
+      ? req.query.maximumTimePeriod : DEFAULT_MAXIMUM_TIME_PERIOD
+    const requireWhitelisted = req.query.requireWhitelisted !== undefined
+      ? req.query.requireWhitelisted === 'true' : DEFAULT_REQUIRED_WHITELISTED
+    const numberOfAuctions = req.query.numberOfAuctions !== undefined
+      ? req.query.numberOfAuctions : DEFAULT_NUMBER_OF_AUCTIONS
 
-      if (!_isValueInRange(maximumTimePeriod, 0, TWO_WEEKS_IN_SECONDS)) {
-        const error = new Error('Invalid `maximumTimePeriod`. This value should be between 1 and 1296000, equivalent to 2 weeks in seconds.')
-        error.type = 'INVALID_MAXIMUM_TIME_PERIOD'
+    if (!_isValueInRange(maximumTimePeriod, 0, TWO_WEEKS_IN_SECONDS)) {
+      const error = new Error('Invalid `maximumTimePeriod`. This value should be between 1 and 1296000, equivalent to 2 weeks in seconds.')
+      error.type = 'INVALID_MAXIMUM_TIME_PERIOD'
+      error.status = 412
+      throw error
+    }
+    if (!_isValueInRange(numberOfAuctions, 1, DEFAULT_MAX_NUMBER_OF_AUCTIONS)) {
+      const error = new Error('Invalid `numberOfAuctions`. This value should be between 1 and ' +
+        DEFAULT_MAX_NUMBER_OF_AUCTIONS + ', equivalent to 2 weeks of auctions running continously + 1 to make it odd as required by contract.')
+      error.type = 'INVALID_NUMBER_OF_AUCTIONS'
+      error.status = 412
+      throw error
+    }
+    addCacheHeader({ res, time: CACHE_TIMEOUT_SHORT })
+    return dxInfoService.getOraclePriceCustom({ token, time, maximumTimePeriod, requireWhitelisted, numberOfAuctions })
+  }
+
+  routes.push({
+    path: '/:tokenPair/prices/custom-median',
+    get (req, res) {
+      const { sellToken, buyToken } = _tokenPairSplit(req.params.tokenPair)
+      const isSellTokenEth = dxInfoService.isTokenEth(sellToken)
+      const isBuyTokenEth = dxInfoService.isTokenEth(buyToken)
+
+      if (isSellTokenEth) {
+        // Price oracle always returns tokenA-WETH.
+        // We do inverse of result to return WETH-tokenA for convenience
+        return _customMedian(req, res, buyToken).then(result => {
+          return ONE.div(result)
+        })
+      } else if (isBuyTokenEth) {
+        return _customMedian(req, res, sellToken)
+      } else {
+        const error = new Error('Invalid `tokenPair`. At least one of the tokens must be WETH.')
+        error.type = 'INVALID_TOKEN_PAIR'
         error.status = 412
         throw error
       }
-      if (!_isValueInRange(numberOfAuctions, 1, DEFAULT_MAX_NUMBER_OF_AUCTIONS)) {
-        const error = new Error('Invalid `numberOfAuctions`. This value should be between 1 and ' +
-          DEFAULT_MAX_NUMBER_OF_AUCTIONS + ', equivalent to 2 weeks of auctions running continously + 1 to make it odd as required by contract.')
-        error.type = 'INVALID_NUMBER_OF_AUCTIONS'
-        error.status = 412
-        throw error
-      }
-      addCacheHeader({ res, time: CACHE_TIMEOUT_SHORT })
-      return dxInfoService.getOraclePriceCustom({ token, time, maximumTimePeriod, requireWhitelisted, numberOfAuctions })
     }
   })
 
+  function _simpleMedian (req, res, token) {
+    const auctionIndex = req.query.auctionIndex
+    const numberOfAuctions = req.query.numberOfAuctions !== undefined
+      ? req.query.numberOfAuctions : DEFAULT_NUMBER_OF_AUCTIONS
+    if (!_isValueInRange(numberOfAuctions, 1, DEFAULT_MAX_NUMBER_OF_AUCTIONS)) {
+      const error = new Error('Invalid `numberOfAuctions`. This value should be between 1 and ' +
+        DEFAULT_MAX_NUMBER_OF_AUCTIONS + ', equivalent to 2 weeks of auctions running continously + 1 to make it odd as required by contract.')
+      error.type = 'INVALID_NUMBER_OF_AUCTIONS'
+      error.status = 412
+      throw error
+    }
+    addCacheHeader({ res, time: CACHE_TIMEOUT_SHORT })
+    return dxInfoService.getOraclePricesAndMedian({ token, numberOfAuctions, auctionIndex })
+  }
+
   routes.push({
-    path: '/:token-WETH/prices/simple-median',
+    path: '/:tokenPair/prices/simple-median',
     get (req, res) {
-      const token = req.params.token
-      const auctionIndex = req.query.auctionIndex
-      const numberOfAuctions = req.query.numberOfAuctions !== undefined
-        ? req.query.numberOfAuctions : DEFAULT_NUMBER_OF_AUCTIONS
-      if (!_isValueInRange(numberOfAuctions, 1, DEFAULT_MAX_NUMBER_OF_AUCTIONS)) {
-        const error = new Error('Invalid `numberOfAuctions`. This value should be between 1 and ' +
-          DEFAULT_MAX_NUMBER_OF_AUCTIONS + ', equivalent to 2 weeks of auctions running continously + 1 to make it odd as required by contract.')
-        error.type = 'INVALID_NUMBER_OF_AUCTIONS'
+      const { sellToken, buyToken } = _tokenPairSplit(req.params.tokenPair)
+      const isSellTokenEth = dxInfoService.isTokenEth(sellToken)
+      const isBuyTokenEth = dxInfoService.isTokenEth(buyToken)
+
+      if (isSellTokenEth) {
+        // Price oracle always returns tokenA-WETH.
+        // We do inverse of result to return WETH-tokenA for convenience
+        return _simpleMedian(req, res, buyToken).then(result => {
+          return ONE.div(result)
+        })
+      } else if (isBuyTokenEth) {
+        return _simpleMedian(req, res, sellToken)
+      } else {
+        const error = new Error('Invalid `tokenPair`. At least one of the tokens must be WETH.')
+        error.type = 'INVALID_TOKEN_PAIR'
         error.status = 412
         throw error
       }
-      addCacheHeader({ res, time: CACHE_TIMEOUT_SHORT })
-      return dxInfoService.getOraclePricesAndMedian({ token, numberOfAuctions, auctionIndex })
     }
   })
 


### PR DESCRIPTION
Fix auctionRepo checking if token is WETH using symbol. It failed when using address

Add inverse result for median endpoints (now they are able to return tokenA-WETH and WETH-tokenA)
Check that at least one token is WETH for median endpoints. Return a semantic error in any other case