### PR TITLE
Feature/buy bot improve

### DIFF
--- a/src/bots/ClaimBot.js
+++ b/src/bots/ClaimBot.js
@@ -130,10 +130,9 @@ class ClaimBot extends Bot {
         logger.info('Claim as buyer transaction: %s', claimBuyerTransactionResult.tx)
       }
 
-      claimAmounts.forEach(amount => {
-        if (amount) {
-          logger.info('Claimed for address %s. Amounts: %o', this._claimAddress, amount)
-          this._notifyClaimedTokens(amount, this._claimAddress)
+      claimAmounts.forEach(amountDetails => {
+        if (amountDetails) {
+          this._notifyClaimedTokens(amountDetails, this._claimAddress)
         }
       })
       return result
@@ -147,9 +146,9 @@ class ClaimBot extends Bot {
     const { tokenA, tokenB, totalSellerClaims, totalBuyerClaims } = amount
     const tokenPairString = tokenA + '-' + tokenB
 
-    const message = 'The bot claimed for ' + tokenPairString + ': ' +
+    const message = 'Claimed for ' + tokenPairString + ': ' +
       totalSellerClaims + ' tokens as seller, ' +
-      totalBuyerClaims + ' tokens as buyer'
+      totalBuyerClaims + ' tokens as buyer for ' + account
 
     // Log message
     logger.info({

--- a/src/helpers/numberUtil.js
+++ b/src/helpers/numberUtil.js
@@ -6,6 +6,9 @@ const TEN = new BigNumber(10)
 const HUNDRED = new BigNumber(100)
 const TEN_EXP_18 = new BigNumber(1e18)
 
+const DEFAULT_TOKEN_DECIMALS = 18
+const DEFAULT_DECIMALS = 2
+
 function toBigNumber (num) {
   return isBigNumber(num) ? num : new BigNumber(num.toString())
 }
@@ -29,7 +32,7 @@ function toBigNumberFraction (fraction, inDecimal = true) {
 }
 
 function toDecimal (num, decimal) {
-  return toBigNumber(num).div(10**decimal)
+  return toBigNumber(num).div(10 ** decimal)
 }
 
 function isBigNumber (n) {
@@ -38,12 +41,12 @@ function isBigNumber (n) {
   return n instanceof BigNumber
 }
 
-function toWei (num, decimals = 18) {
-  return toBigNumber(num).mul(TEN.toPower(decimals))
+function toWei (num, decimals) {
+  return toBigNumber(num).mul(TEN.toPower(decimals || DEFAULT_TOKEN_DECIMALS))
 }
 
-function fromWei (num, decimals = 18) {
-  return toBigNumber(num).div(TEN.toPower(decimals))
+function fromWei (num, decimals) {
+  return toBigNumber(num).div(TEN.toPower(decimals || DEFAULT_TOKEN_DECIMALS))
 }
 
 function getPercentage ({ part, total }) {
@@ -73,18 +76,18 @@ function getIncrement ({ oldValue, newValue }) {
   }
 }
 
-function round (number, decimals = 2) {
-  return roundAux(number, decimals, 'round')
+function round (number, decimals) {
+  return roundAux(number, decimals || DEFAULT_DECIMALS, 'round')
 }
-function roundUp (number, decimals = 2) {
-  return roundAux(number, decimals, 'ceil')
+function roundUp (number, decimals) {
+  return roundAux(number, decimals || DEFAULT_DECIMALS, 'ceil')
 }
-function roundDown (number, decimals = 2) {
-  return roundAux(number, decimals, 'floor')
+function roundDown (number, decimals) {
+  return roundAux(number, decimals || DEFAULT_DECIMALS, 'floor')
 }
 
-function roundAux (number, decimals = 2, roundFnName) {
-  const factor = 10 ** decimals
+function roundAux (number, decimals, roundFnName) {
+  const factor = 10 ** (decimals || DEFAULT_DECIMALS)
 
   return toBigNumber(number)
     .mul(factor)[roundFnName]()

--- a/src/services/LiquidityService/LiquidityService.js
+++ b/src/services/LiquidityService/LiquidityService.js
@@ -569,11 +569,13 @@ keeps happening`
     let buyLiquidityOperation = null
 
     // Get the percentage that should be bought
-    const percentageThatShouldBeBought = this._getPercentageThatShouldBeBought({
+    const buyRule = this._getMatchingBuyRule({
       buyLiquidityRules,
       currentMarketPrice,
       price
     })
+    const percentageThatShouldBeBought = buyRule ? buyRule.buyRatio : numberUtil.ZERO
+    const warnIfNotEnoughBalance = buyRule.warnIfNotEnoughBalance || false
 
     if (!percentageThatShouldBeBought.isZero()) {
       // Get the buy volume, and the expected buyVolume
@@ -690,7 +692,7 @@ keeps happening`
     return buyLiquidityOperation
   }
 
-  _getPercentageThatShouldBeBought ({ buyLiquidityRules, currentMarketPrice, price }) {
+  _getMatchingBuyRule ({ buyLiquidityRules, currentMarketPrice, price }) {
     // Get the relation between prices
     //  priceRatio = (Pn * Cd) / (Pd * Cn)
     const priceRatio = _getPriceRatio(price, currentMarketPrice)
@@ -708,12 +710,13 @@ keeps happening`
         return thresholdB.buyRatio.comparedTo(thresholdA.buyRatio)
       })
 
-    // Get the matching rule with the highest
-    //  * note that the rules aresorted by buyRatio (in descendant order)
+    // Get the matching rule with the highest buyRatio
+    //  * note that the rules are sorted by buyRatio (in descendant order)
     const buyRule = rules.find(threshold => {
       return threshold.marketPriceRatio.greaterThanOrEqualTo(priceRatio)
     })
-    return buyRule ? buyRule.buyRatio : numberUtil.ZERO
+
+    return buyRule
   }
 
   async _sellTokenToCreateLiquidity ({

--- a/tests/services/LiquidityService.test.js
+++ b/tests/services/LiquidityService.test.js
@@ -75,7 +75,8 @@ test('It should ensureBuyLiquidity', async () => {
 
   // we mock the auction repo
   liquidityService._auctionRepo = new AuctionRepoMock({
-    auctions: _getAuctionsWhereBotShouldBuyEthRdn()
+    auctions: _getAuctionsWhereBotShouldBuyEthRdn(),
+    balances: BALANCES
   })
   // we mock the exchange price repo
   liquidityService._priceRepo = priceRepo
@@ -110,7 +111,8 @@ test('It should not ensureBuyLiquidity if enough buy volume', async () => {
 
   // we mock the auction repo
   liquidityService._auctionRepo = new AuctionRepoMock({
-    auctions: _getAuctionsWhereBotShouldBuyEthRdn()
+    auctions: _getAuctionsWhereBotShouldBuyEthRdn(),
+    balances: BALANCES
   })
   // we mock the exchange price repo
   liquidityService._priceRepo = priceRepo
@@ -167,7 +169,8 @@ test('It should ensureBuyLiquidity if auction has only one side closed', async (
 
   // we mock the auction repo
   liquidityService._auctionRepo = new AuctionRepoMock({
-    auctions: _getAuctionsWithOneSideTheoreticalClosed()
+    auctions: _getAuctionsWithOneSideTheoreticalClosed(),
+    balances: BALANCES
   })
   // we mock the exchange price repo
   liquidityService._priceRepo = priceRepo
@@ -303,11 +306,13 @@ test('It should return token balance for an account', async () => {
   let expectedRdnEthAccountBalance = [{
     amount: new BigNumber('601.112e18'),
     amountInUSD: new BigNumber('2473.57'), // 2473.57588
-    token: 'RDN'
+    token: 'RDN',
+    tokenDecimals: 18
   }, {
     amount: new BigNumber('4.01234e18'),
     amountInUSD: new BigNumber('4020.21'), // 4020.21221108
-    token: 'WETH'
+    token: 'WETH',
+    tokenDecimals: 18
   }]
   expect(rdnEthAccountBalance).toEqual(expectedRdnEthAccountBalance)
 })
@@ -318,6 +323,15 @@ test('It should return token balance for an account', async () => {
 const MINIMUM_SELL_VOLUME = 1000
 
 const UNDER_MINIMUM_FUNDING_WETH = new BigNumber('0.5e18')
+
+const BALANCES = {
+  'RDN': {
+    '0x123': new BigNumber('530.20e18')
+  },
+  'WETH': {
+    '0x123': new BigNumber('2.23154e18')
+  }
+}
 
 async function _hasLowBuyVolume ({ sellToken, buyToken }, auctionRepo) {
   const [buyVolume, sellVolume] = await Promise.all([


### PR DESCRIPTION
This PR is mainly for allowing the buy bot to ensure liquidity even if he holds less tokens than the ones required.

If the bot has less tokens, it'll log it, and submit the maximum buy order he can.

- Allow to define in the rules warnIfNotEnoughBalance
- Do not log concurrent checks in the first 10min (reduce log noise)
- Add 18 decimals as the default for tokens without decimals defined
- Simplify how we get the info for the buy bot